### PR TITLE
Update GetCycleCount64.asm

### DIFF
--- a/source/GetCycleCount64.asm
+++ b/source/GetCycleCount64.asm
@@ -1,10 +1,7 @@
 .code
   GetCycleCount proc 
-    push rdx
-	rdtsc
-	shl rdx, 32
-	or  rax, rdx
-	pop rdx
-	ret
+  cpuid
+  rdtsc
+  ret
   GetCycleCount endp
 end


### PR DESCRIPTION
final fix for loops in RDTSC take me days to figure this out

To prevent this the programmer must serialize the the instruction queue. This can be done by inserting a serializing instruction like CPUID instruction before the RDTSC instruction.