### PR TITLE
use RDTSCP over RDTSC

### DIFF
--- a/source/GetCycleCount64.asm
+++ b/source/GetCycleCount64.asm
@@ -1,7 +1,6 @@
 .code
-  GetCycleCount proc 
-  cpuid
-  rdtsc
-  ret
-  GetCycleCount endp
+GetCycleCount proc	
+rdtscp
+ret
+GetCycleCount endp
 end


### PR DESCRIPTION
RDTSC + CPUID (in reverse order, here) to flush the pipeline, and incurred up to a 60x overhead (!) on a Virtual Machine (my working environment) due to hypercalls and whatnot. This is both with and without HW Virtualization enabled.

Most recently I've come across the RDTSCP* instruction, which seems to do what RDTSC+CPUID did, but more efficiently as it's a newer instruction - only a 1.5x-2x overhead, relatively.