### PR TITLE
did little update

### DIFF
--- a/source/HighResolutionTimer.c
+++ b/source/HighResolutionTimer.c
@@ -16,13 +16,15 @@ inline ULONGLONG GetCycleCount()
 
 LONGLONG GetFrequency(DWORD sleepTime)
 {
+    double clockfreq;
+    SetThreadAffinityMask(GetCurrentThread(), 0x01);
     LARGE_INTEGER fq, st, ed;
     QueryPerformanceFrequency(&fq);
+    clockfreq = fq.QuadPart / 1000000;
     QueryPerformanceCounter(&st);
     LONGLONG begin = GetCycleCount();
     Sleep(sleepTime);
-    QueryPerformanceCounter(&ed);
-    LONGLONG usec = (ed.QuadPart % st.QuadPart) * 1000000 / fq.QuadPart;
+    QueryPerformanceCounter(&ed);   
     LONGLONG end = GetCycleCount();
-    return (end - usec - begin) * fq.QuadPart / (ed.QuadPart - st.QuadPart);
+    return (end - begin) * fq.QuadPart / (ed.QuadPart - st.QuadPart);
 }

--- a/source/HighResolutionTimer.c
+++ b/source/HighResolutionTimer.c
@@ -1,15 +1,16 @@
 #include "HighResolutionTimer.h"
 
 #if _WIN64
-inline ULONGLONG GetCycleCount();
+inline ULONGLONG  GetCycleCount();
 #elif _WIN32
-inline ULONGLONG GetCycleCount()
+inline ULONGLONG  GetCycleCount()
 {
-	__asm
-	{
-		_emit 0x0F;
-		_emit 0x31;
-	}
+    __asm
+    {
+        _emit 0x0F;
+        _emit 0x01;
+        _emit 0xF9;
+    }
 }
 #endif 
 


### PR DESCRIPTION
since we use rdtsc we need SetThreadAffinityMask to the  first core 0 to avoid loops in cores now i reduce the freq to 1 microsecond seems i did mistake on counters thats why its didnt work dont Disable Core 0 its not needed with hyper threading !